### PR TITLE
April Tag Vision, Odometry, and Simulation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "postCreateCommand": "cd /opt && wget 'https://github.com/wpilibsuite/vscode-wpilib/releases/download/v2024.3.1/vscode-wpilib-2024.3.1.vsix'",
+  "features": {
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "/opt/vscode-wpilib-2024.3.1.vsix",
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-gradle",
+        "Mechanical-Advantage.event-deploy-wpilib"
+      ]
+    }
+  }
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,11 +4,21 @@
 
 package frc.robot;
 
+import org.photonvision.simulation.SimCameraProperties;
 import org.xero1425.base.XeroRobot;
 import org.xero1425.simulator.engine.ModelFactory;
 import org.xero1425.simulator.engine.SimulationEngine;
 import org.xero1425.subsystems.oi.OISubsystem;
+import org.xero1425.subsystems.vision.AprilTagVisionIO;
+import org.xero1425.subsystems.vision.AprilTagVisionIOLimelight;
+import org.xero1425.subsystems.vision.AprilTagVisionIOSim;
+import org.xero1425.subsystems.vision.AprilTagVisionSubsystem;
 
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.util.Units;
 import frc.robot.commands.automodes.test.LEDTestAutoModeCommand;
 import frc.robot.subsystems.RobotOISubsystem;
 
@@ -83,6 +93,39 @@ public class Robot extends XeroRobot {
     @Override
     protected OISubsystem createOISubsystem() {
         return new RobotOISubsystem(this) ;
+    }
+
+    @Override
+    protected AprilTagVisionSubsystem createVisionSubsystem() {
+        AprilTagVisionIO visionio;
+
+        if (isReal()) {
+            visionio = new AprilTagVisionIOLimelight("limelight");
+        } else {
+            visionio = new AprilTagVisionIOSim(
+                "sim", // Sim name
+                () -> db_.getState().Pose, // Pose supplier
+                getFieldLayout(), // Field layout
+                new Transform3d( // Robot-Relative Camera Pose
+                    new Translation3d(-0.3549, 0, 0.16),
+                    new Rotation3d(0, Units.degreesToRadians(-40), Units.degreesToRadians(180))
+                ),
+                SimCameraProperties.LL2_960_720() // Camera properties
+            );
+        }
+
+        return new AprilTagVisionSubsystem(
+            visionio,
+            getFieldLayout(), // Field Layout
+            () -> db_.getState().Pose, // Pose supplier
+            estimate -> { // Pose estimate fusing
+                db_.addVisionMeasurement(
+                    estimate.pose,
+                    estimate.timestamp,
+                    VecBuilder.fill(0.7, 0.7, 999999)
+                );
+            }
+        );
     }
 
     @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -46,7 +46,7 @@ public class Robot extends XeroRobot {
     @Override
     public void robotInit() {
         //
-        // The base class will create the drive base and the drive controller.
+        // The base class will create the generic subsystems based on the methods you supply.
         // It assumes an XBox controller for now.
         //
         super.robotInit() ;

--- a/src/main/java/org/xero1425/base/XeroRobot.java
+++ b/src/main/java/org/xero1425/base/XeroRobot.java
@@ -26,6 +26,7 @@ import org.xero1425.simulator.engine.SimulationEngine;
 import org.xero1425.subsystems.oi.OISubsystem;
 import org.xero1425.subsystems.swerve.CommandSwerveDrivetrain;
 import org.xero1425.subsystems.swerve.Telemetry;
+import org.xero1425.subsystems.vision.AprilTagVisionSubsystem;
 
 import com.ctre.phoenix6.mechanisms.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.mechanisms.swerve.SwerveRequest;
@@ -66,12 +67,14 @@ public abstract class XeroRobot extends LoggedRobot {
     private AprilTagFieldLayout layout_ ;
     private boolean auto_modes_created_ ;
 
-    private CommandSwerveDrivetrain db_ ;
+    protected CommandSwerveDrivetrain db_ ;
     private SwerveRequest.SwerveDriveBrake brake_ ;
     private SwerveRequest.RobotCentric pov_move_;
     private SwerveRequest.FieldCentric drive_ ;
 
-    private OISubsystem oi_ ;
+    protected AprilTagVisionSubsystem vision_;
+
+    protected OISubsystem oi_ ;
 
     private String char_subsystem_ ;
     private String char_motor_ ;
@@ -138,10 +141,12 @@ public abstract class XeroRobot extends LoggedRobot {
     protected abstract String getPracticeSerialNumber() ;
     protected abstract void createCompetitionAutoModes() ;
     protected abstract void addRobotSimulationModels() ;
-    protected abstract OISubsystem createOISubsystem() ;
     protected abstract void robotSpecificBindings() ;
     protected abstract String getCharSubsystem() ;
     protected abstract String getCharMotor() ;
+
+    protected abstract OISubsystem createOISubsystem() ;
+    protected abstract AprilTagVisionSubsystem createVisionSubsystem();
 
     public OISubsystem getOISubsystem() {
         return oi_ ;
@@ -193,6 +198,11 @@ public abstract class XeroRobot extends LoggedRobot {
         // Create the drive base
         //
         createDriveBase() ;
+
+        /**
+         * Create Vision Subsystem
+         */
+        vision_ = createVisionSubsystem();
 
         char_subsystem_ = getCharSubsystem() ;
         char_motor_ = getCharMotor() ;

--- a/src/main/java/org/xero1425/struct/vision/XeroFiducial.java
+++ b/src/main/java/org/xero1425/struct/vision/XeroFiducial.java
@@ -1,0 +1,44 @@
+package org.xero1425.struct.vision;
+
+import org.xero1425.base.LimelightHelpers.LimelightTarget_Fiducial;
+
+import edu.wpi.first.util.struct.StructSerializable;
+
+public class XeroFiducial implements StructSerializable {
+
+    public final double id;
+    public final double area;
+    public final double x;
+    public final double y;
+    
+    public XeroFiducial(
+        double id,
+        double area,
+        double x,
+        double y
+    ) {
+        this.id = id;
+        this.area = area;
+        this.x = x;
+        this.y = y;
+    }
+
+    public XeroFiducial(LimelightTarget_Fiducial llFid) {
+        this.id = llFid.fiducialID;
+        this.area = llFid.ta;
+        this.x = llFid.tx;
+        this.y = llFid.ty;
+    }
+
+    public static XeroFiducial[] fromLimelightArray(LimelightTarget_Fiducial[] llArray) {
+        XeroFiducial[] arr = new XeroFiducial[llArray.length];
+
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = new XeroFiducial(llArray[i]);
+        }
+
+        return arr;
+    }
+
+    public static final XeroFiducialStruct struct = new XeroFiducialStruct();
+}

--- a/src/main/java/org/xero1425/struct/vision/XeroFiducialStruct.java
+++ b/src/main/java/org/xero1425/struct/vision/XeroFiducialStruct.java
@@ -1,0 +1,47 @@
+package org.xero1425.struct.vision;
+
+import java.nio.ByteBuffer;
+
+import edu.wpi.first.util.struct.Struct;
+
+public class XeroFiducialStruct implements Struct<XeroFiducial> {
+
+    @Override
+    public Class<XeroFiducial> getTypeClass() {
+        return XeroFiducial.class;
+    }
+
+    @Override
+    public String getTypeString() {
+        return "struct:XeroFiducial";
+    }
+
+    @Override
+    public String getSchema() {
+        return "double id;double area;double x;double y";
+    }
+
+    @Override
+    public int getSize() {
+        return kSizeDouble * 4;
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, XeroFiducial value) {
+        bb.putDouble(value.id);
+        bb.putDouble(value.area);
+        bb.putDouble(value.x);
+        bb.putDouble(value.y);
+    }
+
+    @Override
+    public XeroFiducial unpack(ByteBuffer bb) {
+        return new XeroFiducial(
+            bb.getDouble(),
+            bb.getDouble(),
+            bb.getDouble(),
+            bb.getDouble()
+        );
+    }
+    
+}

--- a/src/main/java/org/xero1425/struct/vision/XeroPoseEstimate.java
+++ b/src/main/java/org/xero1425/struct/vision/XeroPoseEstimate.java
@@ -1,0 +1,31 @@
+package org.xero1425.struct.vision;
+
+import org.xero1425.base.LimelightHelpers.PoseEstimate;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.util.struct.StructSerializable;
+
+public class XeroPoseEstimate implements StructSerializable {
+
+    public final Pose2d pose;
+    public final double timestamp;
+    public final int tagCount;
+    public final boolean valid;
+
+    public XeroPoseEstimate(Pose2d pose, double timestamp, int tagCount, boolean valid) {
+        this.pose = pose;
+        this.timestamp = timestamp;
+        this.tagCount = tagCount;
+        this.valid = valid;
+    }
+
+    public XeroPoseEstimate() {
+        this(new Pose2d(), 0.0, 0, false);
+    }
+
+    public static XeroPoseEstimate of(PoseEstimate llPoseEstimate) {
+        return llPoseEstimate != null ? new XeroPoseEstimate(llPoseEstimate.pose, llPoseEstimate.timestampSeconds, llPoseEstimate.tagCount, true) : new XeroPoseEstimate();
+    }
+
+    public static final XeroPoseEstimateStruct struct = new XeroPoseEstimateStruct();
+}

--- a/src/main/java/org/xero1425/struct/vision/XeroPoseEstimateStruct.java
+++ b/src/main/java/org/xero1425/struct/vision/XeroPoseEstimateStruct.java
@@ -1,0 +1,48 @@
+package org.xero1425.struct.vision;
+
+import java.nio.ByteBuffer;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.util.struct.Struct;
+
+public class XeroPoseEstimateStruct implements Struct<XeroPoseEstimate> {
+
+    @Override
+    public String getSchema() {
+        return "Pose2d pose; double timestamp; int32 tagCount; bool valid";
+    }
+
+    @Override
+    public int getSize() {
+        return Pose2d.struct.getSize() + kSizeDouble + kSizeInt32 + kSizeBool;
+    }
+
+    @Override
+    public Class<XeroPoseEstimate> getTypeClass() {
+        return XeroPoseEstimate.class;
+    }
+
+    @Override
+    public String getTypeString() {
+        return "struct:XeroPoseEstimate";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+        return new Struct<?>[] {Pose2d.struct};
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, XeroPoseEstimate value) {
+        Pose2d.struct.pack(bb, value.pose);
+        bb.putDouble(value.timestamp);
+        bb.putInt(value.tagCount);
+        bb.put((byte) (value.valid ? 1 : 0));
+    }
+
+    @Override
+    public XeroPoseEstimate unpack(ByteBuffer bb) {
+        return new XeroPoseEstimate(Pose2d.struct.unpack(bb), bb.getDouble(), bb.getInt(), bb.get() == 1 ? true : false);
+    }
+   
+}

--- a/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIO.java
+++ b/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIO.java
@@ -1,0 +1,58 @@
+package org.xero1425.subsystems.vision;
+
+import org.littletonrobotics.junction.AutoLog;
+import org.xero1425.struct.vision.XeroFiducial;
+import org.xero1425.struct.vision.XeroPoseEstimate;
+
+import edu.wpi.first.math.geometry.Translation2d;
+
+public interface AprilTagVisionIO {
+
+    @AutoLog
+    public class AprilTagVisionIOInputs {
+        // General Values That Will be Replayed
+        public int simpleID = 0;
+        public double simpleX = 0.0;
+        public double simpleY = 0.0;
+        public double simpleArea = 0.0;
+        public boolean simpleValid = false;
+        
+        public Translation2d[] rawCorners = new Translation2d[] {};
+        public XeroFiducial[] fiducials = new XeroFiducial[] {};
+
+        public XeroPoseEstimate poseEstimate = new XeroPoseEstimate();
+    }
+
+    /**
+     * Updates the inputs object with values from the hardware.
+     * @param inputs The inputs to update
+     */
+    public default void updateInputs(AprilTagVisionIOInputsAutoLogged inputs) {};
+
+    /**
+     * Forces the indicator light on the camera to be off.
+     */
+    public default void forceOff() {};
+
+    /**
+     * Forces the indicator light on the camera to blink.
+     */
+    public default void forceBlink() {};
+
+    /**
+     * Forces the indicator light on the camera to be on.
+     */
+    public default void forceOn() {};
+
+    /**
+     * Resets the indicator light on the camera to be controlled by its own software/pipelines.
+     */
+    public default void resetLed() {};
+
+    /**
+     * Gives the robot orientation to the camera for odometry.
+     * Blue origion, CCW-positive, 0 degrees facing red alliance wall
+     */
+    public default void giveRobotOrientation(double yaw, double yawRate, double pitch, double pitchRate, double roll, double rollRate) {};
+
+}

--- a/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOLimelight.java
+++ b/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOLimelight.java
@@ -1,0 +1,77 @@
+package org.xero1425.subsystems.vision;
+
+import java.util.ArrayList;
+
+import org.xero1425.base.LimelightHelpers;
+import org.xero1425.base.LimelightHelpers.LimelightResults;
+import org.xero1425.base.LimelightHelpers.RawDetection;
+import org.xero1425.struct.vision.XeroFiducial;
+import org.xero1425.struct.vision.XeroPoseEstimate;
+
+import edu.wpi.first.math.geometry.Translation2d;
+
+public class AprilTagVisionIOLimelight implements AprilTagVisionIO {
+
+    private final String name_;
+
+    /**
+     * Creates a new Limelight implementation, this implementation is using the Limelight Lib with a Limelight.
+     * This specifies a name.
+     * @param name The name of the limelight.
+     */
+    public AprilTagVisionIOLimelight(String name) {
+        name_ = name;
+    }
+
+    @Override
+    public void forceOff() {
+        LimelightHelpers.setLEDMode_ForceOff(name_);
+    }
+    
+    @Override
+    public void forceBlink() {
+        LimelightHelpers.setLEDMode_ForceBlink(name_);
+    }
+
+    @Override
+    public void forceOn() {
+        LimelightHelpers.setLEDMode_ForceOn(name_);
+    }
+
+    @Override
+    public void resetLed() {
+        LimelightHelpers.setLEDMode_PipelineControl(name_);
+    }
+
+    @Override
+    public void updateInputs(AprilTagVisionIOInputsAutoLogged inputs) {
+        inputs.simpleX = LimelightHelpers.getTX(name_);
+        inputs.simpleY = LimelightHelpers.getTY(name_);
+        inputs.simpleArea = LimelightHelpers.getTA(name_);
+        inputs.simpleValid = LimelightHelpers.getTV(name_);
+        inputs.simpleID = (int) LimelightHelpers.getFiducialID(name_);
+
+        RawDetection[] detections = LimelightHelpers.getRawDetections(name_);
+        ArrayList<Translation2d> corners = new ArrayList<>();
+
+        for (RawDetection detection : detections) {
+            corners.add(new Translation2d(detection.corner0_X, detection.corner0_Y));
+            corners.add(new Translation2d(detection.corner1_X, detection.corner1_Y));
+            corners.add(new Translation2d(detection.corner2_X, detection.corner2_Y));
+            corners.add(new Translation2d(detection.corner3_X, detection.corner3_Y));
+        }
+
+        inputs.rawCorners = corners.toArray(new Translation2d[0]);
+        
+        LimelightResults results = LimelightHelpers.getLatestResults(name_);
+        inputs.fiducials = XeroFiducial.fromLimelightArray(results.targets_Fiducials);
+
+        inputs.poseEstimate = XeroPoseEstimate.of(LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(name_));
+    }
+
+    @Override
+    public void giveRobotOrientation(double yaw, double yawRate, double pitch, double pitchRate, double roll, double rollRate) {
+        LimelightHelpers.SetRobotOrientation(name_, yaw, 0, 0, 0, 0, 0);
+    }
+
+}

--- a/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOPhoton.java
+++ b/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOPhoton.java
@@ -1,0 +1,120 @@
+package org.xero1425.subsystems.vision;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.common.hardware.VisionLEDMode;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import org.photonvision.targeting.TargetCorner;
+import org.xero1425.struct.vision.XeroFiducial;
+import org.xero1425.struct.vision.XeroPoseEstimate;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+public class AprilTagVisionIOPhoton implements AprilTagVisionIO {
+
+    // Transform from robot to camera.
+    protected final Transform3d robotToCamera_;
+
+    protected final PhotonCamera camera_;
+    private final PhotonPoseEstimator poseEstimator_;
+
+    public AprilTagVisionIOPhoton(String name, AprilTagFieldLayout layout, Transform3d robotToCamera) {
+        // Setup camera
+        camera_ = new PhotonCamera(name);
+
+        robotToCamera_ = robotToCamera;
+
+        // Setup pose estimator
+        poseEstimator_ = new PhotonPoseEstimator(
+            layout,
+            PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
+            camera_,
+            robotToCamera_
+        );
+    }
+
+    @Override
+    public void updateInputs(AprilTagVisionIOInputsAutoLogged inputs) {
+        PhotonPipelineResult result = camera_.getLatestResult();
+        PhotonTrackedTarget bestTarget = result.getBestTarget();
+
+        // Simple setup
+        if (bestTarget != null) {
+            inputs.simpleID = bestTarget.getFiducialId();
+            inputs.simpleX = bestTarget.getPitch();
+            inputs.simpleY = bestTarget.getYaw();
+            inputs.simpleArea = bestTarget.getArea();
+            inputs.simpleValid = true;
+        } else {
+            inputs.simpleID = 0;
+            inputs.simpleX = 0.0;
+            inputs.simpleY = 0.0;
+            inputs.simpleArea = 0.0;
+            inputs.simpleValid = false;
+        }
+
+        // Target information to fill
+        ArrayList<Translation2d> cornerCoords = new ArrayList<>();
+        ArrayList<XeroFiducial> fiducials = new ArrayList<>();
+
+        // Get target information
+        for (PhotonTrackedTarget target : result.getTargets()) {
+
+            for (TargetCorner corner : target.getDetectedCorners()) {
+                cornerCoords.add(new Translation2d(corner.x, corner.y));
+            }
+
+            fiducials.add(new XeroFiducial(
+                target.getFiducialId(),
+                target.getArea(),
+                target.getPitch(),
+                target.getYaw()
+            ));
+        }
+
+        inputs.rawCorners = cornerCoords.toArray(new Translation2d[0]);
+        inputs.fiducials = fiducials.toArray(new XeroFiducial[0]);
+
+        Optional<EstimatedRobotPose> optionalPhotonEstimate = poseEstimator_.update();
+
+        optionalPhotonEstimate.ifPresentOrElse(photonEstimate -> {
+            inputs.poseEstimate = new XeroPoseEstimate(
+                photonEstimate.estimatedPose.toPose2d(),
+                photonEstimate.timestampSeconds,
+                photonEstimate.targetsUsed.size(),
+                true
+            );
+        }, () -> {
+            inputs.poseEstimate = new XeroPoseEstimate();
+        });
+    }
+
+    @Override
+    public void forceBlink() {
+        camera_.setLED(VisionLEDMode.kBlink);
+    }
+
+    @Override
+    public void forceOff() {
+        camera_.setLED(VisionLEDMode.kOff);
+    }
+
+    @Override
+    public void forceOn() {
+        camera_.setLED(VisionLEDMode.kOn);
+    }
+
+    @Override
+    public void resetLed() {
+        camera_.setLED(VisionLEDMode.kDefault);
+    }
+
+}

--- a/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOSim.java
+++ b/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionIOSim.java
@@ -1,0 +1,48 @@
+package org.xero1425.subsystems.vision;
+
+import java.util.function.Supplier;
+
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Transform3d;
+
+public class AprilTagVisionIOSim extends AprilTagVisionIOPhoton {
+
+    private final VisionSystemSim sim_;
+    private final PhotonCameraSim camSim_;
+    private final SimCameraProperties camProps_;
+
+    private final Supplier<Pose2d> robotPoseSupplier_;
+
+    public AprilTagVisionIOSim(String name, Supplier<Pose2d> robotPoseSupplier, AprilTagFieldLayout layout, Transform3d robotToCamera, SimCameraProperties camProps) {
+        super(name, layout, robotToCamera);
+        
+        // Create vision sim
+        sim_ = new VisionSystemSim(name);
+        
+        // Setup apriltags in sim
+        sim_.addAprilTags(layout);
+        
+        // Properties for camera simulation
+        camProps_ = camProps;
+        
+        // Setup camera sim
+        camSim_ = new PhotonCameraSim(camera_, camProps_);
+        camSim_.enableDrawWireframe(true);
+        
+        sim_.addCamera(camSim_, robotToCamera_);
+
+        robotPoseSupplier_ = robotPoseSupplier;
+    }
+
+    @Override
+    public void updateInputs(AprilTagVisionIOInputsAutoLogged inputs) {
+        sim_.update(robotPoseSupplier_.get());
+        super.updateInputs(inputs);
+    }
+    
+}

--- a/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionSubsystem.java
+++ b/src/main/java/org/xero1425/subsystems/vision/AprilTagVisionSubsystem.java
@@ -1,0 +1,226 @@
+package org.xero1425.subsystems.vision;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.littletonrobotics.junction.AutoLogOutput;
+import org.littletonrobotics.junction.Logger;
+import org.xero1425.struct.vision.XeroFiducial;
+import org.xero1425.struct.vision.XeroPoseEstimate;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class AprilTagVisionSubsystem extends SubsystemBase {
+
+    private final AprilTagVisionIO io_;
+    private final AprilTagVisionIOInputsAutoLogged inputs_;
+    
+    private final AprilTagFieldLayout layout_;
+
+    private Supplier<Pose2d> poseSupplier_;
+    private Consumer<XeroPoseEstimate> megatagConsumer_;
+
+    @AutoLogOutput(key = "AprilTagVision/LastValidTargetTimestamp")
+    private double lastValidTargetTimestamp_;
+
+    /**
+     * Creates a vision subsystem.
+     * @param io The IO implementation to use
+     * @param layout The current field layout for the game
+     * @param poseSupplier A supplier that gets the current estimated robot pose
+     * @param megatagConsumer A consumer which takes a new estimated pose and fuses it into pose.
+     */
+    public AprilTagVisionSubsystem(AprilTagVisionIO io, AprilTagFieldLayout layout, Supplier<Pose2d> poseSupplier, Consumer<XeroPoseEstimate> megatagConsumer) {
+        io_ = io;
+        inputs_ = new AprilTagVisionIOInputsAutoLogged();
+        layout_ = layout;
+
+        poseSupplier_ = poseSupplier;
+        megatagConsumer_ = megatagConsumer;
+        lastValidTargetTimestamp_ = 0;
+    }
+
+    @Override
+    public void periodic() {
+        io_.updateInputs(inputs_);
+        Logger.processInputs(getName(), inputs_);
+
+        // give the camera an orientation
+        io_.giveRobotOrientation(poseSupplier_.get().getRotation().getDegrees(), 0, 0, 0, 0, 0);
+                
+        // give the megatag2 estimate to consumers (ex. drivebase vision measurement)
+        megatagConsumer_.accept(inputs_.poseEstimate);
+
+        if (hasValidTarget()) {
+            lastValidTargetTimestamp_ = Timer.getFPGATimestamp();
+        }
+
+        // Creates an array of poses of the currently visible tags. This is useful for seeing which tags the robot can see visually.
+        ArrayList<Pose3d> validTargetPoses = new ArrayList<Pose3d>();
+
+        for (XeroFiducial fiducial : inputs_.fiducials) {
+            layout_.getTagPose((int) fiducial.id).ifPresent((pose) -> {
+                validTargetPoses.add(pose);
+            });
+        }
+
+        Logger.recordOutput(getName() + "/ValidTargetPoses", validTargetPoses.toArray(new Pose3d[0]));
+    }
+
+    /**
+     * Forces the camera indicator LED to be off.
+     */
+    public Command forceLedOff() {
+        return runOnce(io_::forceOff);
+    }
+
+    /**
+     * Forces the camera indicator LED to blink.
+     */
+    public Command forceLedBlink() {
+        return runOnce(io_::forceBlink);
+    }
+
+    /**
+     * Forces the camera indicator LED to be on.
+     */
+    public Command forceLedOn() {
+        return runOnce(io_::forceOn);
+    }
+
+    /**
+     * Sets the camera indicator LED back to the default state, controlled by the camera software itself.
+     */
+    public Command resetLed() {
+        return runOnce(io_::resetLed);
+    }
+
+    /**
+     * Gets estimated information from the regular pose estimation.
+     * @return Estimated pose.
+     */
+    public XeroPoseEstimate getPoseEstimate() {
+        return inputs_.poseEstimate;
+    }
+
+    /**
+     * Figures out if its currently seeing a specific april tag.
+     * @param id The id of the april tag.
+     * @return Whether or not the camera can currently see the specified april tag.
+     */
+    public boolean hasAprilTag(int id) {
+        return findFid(id).isPresent();
+    }
+
+    /**
+     * Finds if a valid target exists.
+     * @return Whether or not a valid target exists.
+     */
+    public boolean hasValidTarget() {
+        return inputs_.simpleValid;
+    }
+
+    /**
+     * Gets the id of the primary in-view Fiducial/Apriltag
+     * @return
+     */
+    public int getSimpleID() {
+        return inputs_.simpleID;
+    }
+
+    /**
+     * Gets the vision targets X offset. Make sure to check if the robot is seeing a tag, and its the one you want first. Otherwise this data will be innaccurate.
+     * @return Its X offset in degrees from the center of the camera. +X Right +Y Down
+     */
+    public double getSimpleX() {
+        return inputs_.simpleX;
+    }
+
+    /**
+     * Gets the vision targets Y offset. Make sure to check if the robot is seeing a tag, and its the one you want first. Otherwise this data will be innaccurate.
+     * @return Its Y offset in degrees from the center of the camera. +X Right +Y Down
+     */
+    public double getSimpleY() {
+        return inputs_.simpleY;
+    }
+
+    /**
+     * Gets the vision targets area on the camera. Make sure to check if the robot is seeing a tag, and its the one you want first. Otherwise this data will be innaccurate.
+     * @return How much of the camera the target covers. This range is configured in the camera tuning.
+     */
+    public double getSimpleArea() {
+        return inputs_.simpleArea;
+    }
+
+    /**
+     * Gets a specific apriltag's X offset. Make sure to check if the robot can see the tag first. Otherwise this data will be innaccurate.
+     * @param id The id of the apriltag.
+     * @return Its X offset in degrees from the center of the camera. +X Right +Y Down
+     */
+    public Optional<Double> getSpecificX(int id) {
+        Optional<XeroFiducial> fid = findFid(id);
+
+        if (fid.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(fid.get().x);
+    }
+
+    /**
+     * Gets a specific apriltag's Y offset. Make sure to check if the robot can see the tag first. Otherwise this data will be innaccurate.
+     * @param id The id of the apriltag.
+     * @return Its Y offset in degrees from the center of the camera. +X Right +Y Down
+     */
+    public Optional<Double> getSpecificY(int id) {
+        Optional<XeroFiducial> fid = findFid(id);
+
+        if (fid.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(fid.get().y);
+    }
+
+    /**
+     * Gets a specific apriltag's area on the camera. Make sure to check if the robot can see the tag first. Otherwise this data will be innaccurate.
+     * @param id The id of the apriltag.
+     * @return How much of the camera the tag covers. This range is configured in the camera tuning.
+     */
+    public Optional<Double> getSpecificArea(int id) {
+        Optional<XeroFiducial> fid = findFid(id);
+
+        if (fid.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(fid.get().area);
+    }
+
+    /**
+     * Gets the time since theres been a valid target.
+     * @return The time elapsed, in seconds.
+     */
+    public double getTimeSinceValidTarget() {
+        return Timer.getFPGATimestamp() - lastValidTargetTimestamp_;
+    }
+
+    /**
+     * Finds a fidicial object in the array.
+     * @return The fidicial, null if not found.
+     */
+    private Optional<XeroFiducial> findFid(int id) {
+        for (XeroFiducial fid : inputs_.fiducials) {
+            if (fid.id == (double) id) {
+                return Optional.of(fid);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,57 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2024.3.1",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
+    "frcYear": "2024",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-cpp",
+            "version": "v2024.3.1",
+            "libName": "photonlib",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-cpp",
+            "version": "v2024.3.1",
+            "libName": "photontargeting",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photonlib-java",
+            "version": "v2024.3.1"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "photontargeting-java",
+            "version": "v2024.3.1"
+        }
+    ]
+}


### PR DESCRIPTION
Adds AprilTagVision subsystems from the student codebase, this allows for complete vision simulation, megatag2 odometry, and even has photonvision support if we ever decide to use it, which its inclusion is what allows for simulation.

The only thing we need to do before merging is to test this on a robot and simulation, as I wrote it on a chromebook and cannot test anything, only build. It should work however since its mostly copied from the student code that has been confirmed to work.